### PR TITLE
Fix unit tests.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 # Include python requirements here
-charmhelpers
+git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 charms.reactive

--- a/src/tests/unit/requirements.txt
+++ b/src/tests/unit/requirements.txt
@@ -1,8 +1,9 @@
 # Include python requirements here
-charmhelpers
+git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 charms.reactive
 mock
 pytest
 pytest-cov
 os-client-config
 os-testr>=0.4.1
+netifaces


### PR DESCRIPTION
- charmhelpers does not have a new release since 2022 on PyPy so it doesn't recognize new ubuntu releases. The main branch has the new releases, which fixes the unit tests
- netifaces was missing from the unit tests requirements.