### PR TITLE
Fix charm install hook by pinning setuptools

### DIFF
--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,3 +1,5 @@
 # https://github.com/juju-solutions/layer-basic/issues/210
 Jinja2<3.0;python_version == '3.8'
+# https://github.com/pypa/setuptools/issues/4483
+setuptools==70.0.0
 netifaces


### PR DESCRIPTION
- pin setuptools to be able to install without errors
- Setuptools 71 will prefer installed dependencies over the vendored ones and this is currently breaking the instalation

More details can be found at:
- https://github.com/pypa/setuptools/issues/4483
- https://github.com/pypa/packaging-problems/issues/342