### PR TITLE
refactor: migrate libjuju to jubilant

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
   release:
     needs: check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -5,152 +5,85 @@ Reusable pytest fixtures for functional testing.
 Environment variables
 ---------------------
 
-test_preserve_model:
-if set, the testing model won't be torn down at the end of the testing session
+PYTEST_KEEP_MODEL:
+    If set, the testing model won't be torn down at the end of the testing session.
+
+PYTEST_CLOUD_NAME:
+    Name of the cloud (and optionally region as ``cloud/region``) to use for the model.
+
+PYTEST_CLOUD_REGION:
+    Cloud region. If set alongside PYTEST_CLOUD_NAME, the two are combined as
+    ``cloud/region`` when adding the model.
+
+PYTEST_CLOUD_CREDENTIAL:
+    Credential name to use when adding the model.
 """
 
-import asyncio
 import os
-import subprocess
 import uuid
 
-import juju
-import pytest_asyncio
-from juju.controller import Controller
-from juju.errors import JujuError
+import jubilant
+import pytest
 
 
-@pytest_asyncio.fixture(scope="module")
-def event_loop():
-    """Override the default pytest event loop.
+@pytest.fixture(scope="module")
+def juju():
+    """Create a temporary Juju model and yield a :class:`jubilant.Juju` instance.
 
-    Do this too allow for fixtures using a broader scope.
+    Destroys the model after the tests complete unless ``PYTEST_KEEP_MODEL`` is set.
     """
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.set_debug(True)
-    yield loop
-    loop.close()
-    asyncio.set_event_loop(None)
-
-
-@pytest_asyncio.fixture(scope="module")
-async def controller():
-    """Connect to the current controller."""
-    _controller = Controller()
-    await _controller.connect_current()
-    yield _controller
-    await _controller.disconnect()
-
-
-@pytest_asyncio.fixture(scope="module")
-async def model(controller):
-    """Live only for the duration of the test."""
-    model_name = "functest-{}".format(str(uuid.uuid4())[-12:])
-    _model = await controller.add_model(
-        model_name,
-        cloud_name=os.getenv("PYTEST_CLOUD_NAME"),
-        region=os.getenv("PYTEST_CLOUD_REGION"),
-        credential_name=os.getenv("PYTEST_CLOUD_CREDENTIAL"),
+    model_name = "functest-{}".format(uuid.uuid4().hex[:12])
+    cloud_name = os.getenv("PYTEST_CLOUD_NAME")
+    cloud_region = os.getenv("PYTEST_CLOUD_REGION")
+    credential = os.getenv("PYTEST_CLOUD_CREDENTIAL")
+    cloud_arg = (
+        "{}/{}".format(cloud_name, cloud_region) if cloud_name and cloud_region else cloud_name
     )
-    # https://github.com/juju/python-libjuju/issues/267
-    subprocess.check_call(["juju", "models"])
-    while model_name not in await controller.list_models():
-        await asyncio.sleep(1)
-    yield _model
-    await _model.disconnect()
+
+    juju = jubilant.Juju()
+    juju.add_model(model_name, cloud=cloud_arg, credential=credential)
+    yield juju
     if not os.getenv("PYTEST_KEEP_MODEL"):
-        await controller.destroy_model(model_name)
-        while model_name in await controller.list_models():
-            await asyncio.sleep(1)
+        juju.destroy_model(model_name)
 
 
-@pytest_asyncio.fixture
-async def get_unit(model):
-    """Return the requested <app_name>/<unit_number> unit."""  # noqa D202
+@pytest.fixture
+def file_contents(juju):
+    """Return the contents of a file on a remote unit.
 
-    async def _get_unit(name):
-        try:
-            (app_name, unit_number) = name.split("/")
-            return model.applications[app_name].units[unit_number]
-        except (KeyError, ValueError):
-            raise JujuError("Cannot find unit {}".format(name))
+    :param path: Absolute file path on the remote unit.
+    :param unit: Unit name, e.g. ``advanced-routing-noble/0``.
+    """
 
-    return _get_unit
-
-
-@pytest_asyncio.fixture
-async def run_command(get_unit):
-    """Run a command on a unit.
-
-    :param cmd: Command to be run
-    :param target: Unit object or unit name string
-    """  # noqa D202
-
-    async def _run_command(cmd, target):
-        unit = target if type(target) is juju.unit.Unit else await get_unit(target)
-        action = await unit.run(cmd)
-        await action.wait()
-        return action.results
-
-    return _run_command
-
-
-@pytest_asyncio.fixture
-async def get_app(model):
-    """Return the application by name in the model."""  # noqa D202
-
-    async def _get_app(name):
-        try:
-            return model.applications[name]
-        except KeyError:
-            raise JujuError("Cannot find application {}".format(name))
-
-    return _get_app
-
-
-@pytest_asyncio.fixture
-async def file_contents(run_command):
-    """Return the contents of a file.
-
-    :param path: File path
-    :param target: Unit object or unit name string
-    """  # noqa D202
-
-    async def _file_contents(path, target):
-        cmd = "cat {}".format(path)
-        results = await run_command(cmd, target)
-        return results["stdout"]
+    def _file_contents(path, unit):
+        return juju.exec("cat {}".format(path), unit=unit).stdout
 
     return _file_contents
 
 
-@pytest_asyncio.fixture
-async def file_exists(run_command):
-    """Return 1 or 0 based on if file exists or not in target unit.
+@pytest.fixture
+def file_exists(juju):
+    """Return '1' or '0' (with trailing newline) based on whether a file exists on a remote unit.
 
-    :param path: File path
-    :param target: Unit object or unit name string
-    """  # noqa D202
+    :param path: Absolute file path on the remote unit.
+    :param unit: Unit name, e.g. ``advanced-routing-noble/0``.
+    """
 
-    async def _file_exists(path, target):
-        cmd = '[ -f "{}" ] && echo 1 || echo 0'.format(path)
-        results = await run_command(cmd, target)
-        return results["stdout"]
+    def _file_exists(path, unit):
+        return juju.exec('[ -f "{}" ] && echo 1 || echo 0'.format(path), unit=unit).stdout
 
     return _file_exists
 
 
-@pytest_asyncio.fixture
-async def reconfigure_app(get_app, model):
-    """Apply a different config to the requested app."""  # noqa D202
+@pytest.fixture
+def reconfigure_app(juju):
+    """Apply a config mapping to an application and wait for it to become active."""
 
-    async def _reconfigure_app(cfg, target):
-        application = (
-            target if type(target) is juju.application.Application else await get_app(target)
+    def _reconfigure_app(cfg, app):
+        juju.config(app, cfg)
+        juju.wait(
+            lambda status: status.apps[app].is_active,
+            timeout=300,
         )
-        await application.set_config(cfg)
-        await application.get_config()
-        await model.block_until(lambda: application.status == "active")
 
     return _reconfigure_app

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,9 +1,4 @@
-flake8
-juju
+jubilant
 mock
 pytest
-# Breaking change after 0.23, asyncio_event_loop was been removed.
-# Instead of spending time to fix functional test for version after 0.23,
-# We should spend time to follow up with pytest-operator or zaza.
-pytest-asyncio<0.23
 requests

--- a/tests/functional/test_routing.py
+++ b/tests/functional/test_routing.py
@@ -1,55 +1,71 @@
 """Main module for functional testing."""
 
-import asyncio
 import json
 import os
+import time
 
 import cfg_opts
+import jubilant
 import pytest
-import pytest_asyncio
 
-pytestmark = pytest.mark.asyncio
 SERIES = [
     "noble",
     "jammy",
     "focal",
 ]
 
+# Juju 3.x uses bases instead of series names.
+SERIES_TO_BASE = {
+    "noble": "ubuntu@24.04",
+    "jammy": "ubuntu@22.04",
+    "focal": "ubuntu@20.04",
+}
+
 ############
 # FIXTURES #
 ############
 
 
-@pytest_asyncio.fixture(scope="module", params=SERIES)
-async def deploy_app(request, model):
-    """Deploy the advanced-routing charm as a subordinate of ubuntu."""
-    release = request.param
-    built_charm = os.getenv(f"CHARM_PATH_{release.upper()}")
+@pytest.fixture(scope="module", params=SERIES)
+def deploy_app(request, juju):
+    """Deploy the advanced-routing charm as a subordinate of ubuntu.
 
-    await model.deploy(
+    Yields the application name of the deployed advanced-routing charm as a string.
+    """
+    release = request.param
+    base = SERIES_TO_BASE[release]
+    built_charm = os.getenv("CHARM_PATH_{}".format(release.upper()))
+    ubuntu_app = "ubuntu-{}".format(release)
+    routing_app = "advanced-routing-{}".format(release)
+
+    juju.deploy(
         "ubuntu",
-        application_name="ubuntu-{}".format(release),
-        series=release,
+        ubuntu_app,
+        base=base,
         channel="stable",
     )
-    advanced_routing = await model.deploy(
+    juju.deploy(
         built_charm,
-        application_name="advanced-routing-{}".format(release),
-        series=release,
-        num_units=0,
+        routing_app,
+        base=base,
     )
-    await model.add_relation(
-        "ubuntu-{}".format(release),
-        "advanced-routing-{}".format(release),
-    )
+    juju.integrate(ubuntu_app, routing_app)
 
-    yield advanced_routing
+    yield routing_app
 
 
-@pytest_asyncio.fixture(scope="module")
-async def unit(deploy_app):
-    """Return the advanced-routing unit we've deployed."""
-    return deploy_app.units.pop()
+@pytest.fixture(scope="module")
+def unit(juju, deploy_app):
+    """Return the advanced-routing unit name for the deployed app.
+
+    The unit name is resolved once from the live model status after the app has
+    been deployed.  Using a stable string avoids the fragile ``.pop()`` pattern
+    of the old python-libjuju tests, which could exhaust the unit list across
+    parametrized test calls.
+    """
+    status = juju.status()
+    units = status.get_units(deploy_app)
+    return next(iter(units))
 
 
 #########
@@ -57,89 +73,88 @@ async def unit(deploy_app):
 #########
 
 
-async def test_deploy(deploy_app, model):
-    """Test the deployment."""
-    status, message = "blocked", "Advanced routing is disabled"
-    await model.block_until(
-        lambda: (
-            deploy_app.status == status
-            and all(unit.workload_status_message == message for unit in deploy_app.units)
+def test_deploy(deploy_app, juju):
+    """Test the deployment reaches the expected blocked state."""
+    juju.wait(
+        lambda status: (
+            status.apps.get(deploy_app) is not None
+            and status.apps[deploy_app].is_blocked
+            and all(
+                u.workload_status.message == "Advanced routing is disabled"
+                for u in status.get_units(deploy_app).values()
+            )
         ),
         timeout=1200,
     )
-    assert True
 
 
 @pytest.mark.parametrize(
     "cfg",
     [pytest.param(cfg, id="cfg-{}".format(i)) for i, cfg in enumerate(cfg_opts.JSON_CONFIGS)],
 )
-async def test_juju_routing(cfg, file_contents, file_exists, deploy_app, model):
+def test_juju_routing(cfg, file_contents, file_exists, deploy_app, unit, juju):
     """Test juju routing file contents with config."""
     json_config = cfg["input"]
-    await deploy_app.set_config(
+    juju.config(
+        deploy_app,
         {
             "advanced-routing-config": json.dumps(json_config),
             "enable-advanced-routing": "true",
             "action-managed-update": "false",
-        }
+        },
     )
 
-    status, agent_status, message = "active", "idle", "Unit is ready"
-    await model.block_until(
-        lambda: (
-            deploy_app.status == status
+    juju.wait(
+        lambda status: (
+            status.apps.get(deploy_app) is not None
+            and status.apps[deploy_app].is_active
             and all(
-                unit.agent_status == agent_status and unit.workload_status_message == message
-                for unit in deploy_app.units
+                u.juju_status.current == "idle" and u.workload_status.message == "Unit is ready"
+                for u in status.get_units(deploy_app).values()
             )
         ),
         timeout=300,
     )
 
     # NOTE(gabrielcocenza) files might take more time to be rendered.
-    await asyncio.sleep(10)
+    time.sleep(10)
 
     common_path = "/usr/local/lib/juju-charm-advanced-routing"
     up_path = "{}/if-up/95-juju_routing".format(common_path)
     cleanup_path = "{}/cleanup/95-juju_routing".format(common_path)
-    unit = deploy_app.units.pop()
 
-    if_up_content = await file_contents(path=up_path, target=unit)
-    if_down_content = await file_contents(path=cleanup_path, target=unit)
+    if_up_content = file_contents(up_path, unit)
+    if_down_content = file_contents(cleanup_path, unit)
 
-    if_up_expected_content = cfg["expected_ifup"]
-    if_down_expected_content = cfg["expected_ifdown"]
+    assert cfg["expected_ifup"] == if_up_content
+    assert cfg["expected_ifdown"] == if_down_content
 
-    assert if_up_expected_content == if_up_content
-    assert if_down_expected_content == if_down_content
-
-    series = deploy_app.name.split("-")[-1]
+    series = deploy_app.split("-")[-1]
     if series >= "xenial" or series < "bionic":
         ifup_path = "/etc/network/if-up.d"
     else:
         ifup_path = "/etc/networkd-dispatcher/routable.d"
 
     ifup_expected_file_path = "{}/95-juju_routing".format(ifup_path)
-    ifup_exists = await file_exists(path=ifup_expected_file_path, target=unit)
-    assert ifup_exists == "1\n"
+    assert file_exists(ifup_expected_file_path, unit) == "1\n"
 
 
-async def test_juju_routing_disable(file_exists, unit, deploy_app, model):
-    """Test juju routing file non-existance when conf disabled."""
-    status, message = "blocked", "Advanced routing is disabled"
-
-    await deploy_app.set_config({"enable-advanced-routing": "false"})
-    await model.block_until(
-        lambda: (
-            deploy_app.status == status
-            and all(unit.workload_status_message == message for unit in deploy_app.units)
+def test_juju_routing_disable(file_exists, unit, deploy_app, juju):
+    """Test juju routing file non-existence when conf disabled."""
+    juju.config(deploy_app, {"enable-advanced-routing": "false"})
+    juju.wait(
+        lambda status: (
+            status.apps.get(deploy_app) is not None
+            and status.apps[deploy_app].is_blocked
+            and all(
+                u.workload_status.message == "Advanced routing is disabled"
+                for u in status.get_units(deploy_app).values()
+            )
         ),
         timeout=300,
     )
 
-    series = deploy_app.name.split("-")[-1]
-
+    series = deploy_app.split("-")[-1]
     if series >= "xenial" or series < "bionic":
         ifup_path = "/etc/network/if-up.d"
         ifdown_path = "/etc/network/if-down.d"
@@ -149,39 +164,33 @@ async def test_juju_routing_disable(file_exists, unit, deploy_app, model):
 
     for if_path in [ifup_path, ifdown_path]:
         filename = "{}/95-juju_routing".format(if_path)
-        if_exists = await file_exists(path=filename, target=unit)
-        assert if_exists == "0\n"
+        assert file_exists(filename, unit) == "0\n"
 
 
-async def test_apply_changes_disabled(file_exists, deploy_app, unit):
-    """Tests that apply-changes action complete."""
-    await deploy_app.set_config(
-        {"enable-advanced-routing": "false", "action-managed-update": "true"}
+def test_apply_changes_disabled(deploy_app, unit, juju):
+    """Test that the apply-changes action fails when advanced routing is disabled."""
+    juju.config(
+        deploy_app,
+        {"enable-advanced-routing": "false", "action-managed-update": "true"},
     )
-    action = await unit.run_action("apply-changes")
-    action = await action.wait()
-    assert action.status == "failed"
+    with pytest.raises(jubilant.TaskError):
+        juju.run(unit, "apply-changes")
 
 
-async def test_apply_changes(file_exists, deploy_app, unit):
-    """Tests that apply-changes action complete."""
+def test_apply_changes(file_exists, deploy_app, unit, juju):
+    """Test that the apply-changes action completes when advanced routing is enabled."""
     ifup_path = "/etc/networkd-dispatcher/routable.d"
     ifup_filename = "{}/95-juju_routing".format(ifup_path)
-    ifup_exists = await file_exists(path=ifup_filename, target=unit)
 
     # ifup file doesn't exist before running the action
-    assert ifup_exists == "0\n"
+    assert file_exists(ifup_filename, unit) == "0\n"
 
-    await deploy_app.set_config(
-        {"enable-advanced-routing": "true", "action-managed-update": "true"}
+    juju.config(
+        deploy_app,
+        {"enable-advanced-routing": "true", "action-managed-update": "true"},
     )
-
-    unit = deploy_app.units[0]
-    action = await unit.run_action("apply-changes")
-    action = await action.wait()
-    assert action.status == "completed"
-
-    ifup_exists = await file_exists(path=ifup_filename, target=unit)
+    juju.run(unit, "apply-changes")
+    # TaskError would have been raised on failure; reaching here means the action completed.
 
     # ifup file exists after running the action
-    assert ifup_exists == "1\n"
+    assert file_exists(ifup_filename, unit) == "1\n"

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ setenv =
 deps =
   pytest
   pytest-cov
-  pytest-operator
   -r {toxinidir}/requirements.txt
   -r {toxinidir}/tests/functional/requirements.txt
 commands = pytest {toxinidir}/tests/functional \


### PR DESCRIPTION
libjuju not longer works with ubuntu@26.04, let's migrate to jubilant for the functional test

assisted by claude sonnet 4.6 (opencode)